### PR TITLE
배경의 backdrop-filter를 filter로 변경

### DIFF
--- a/src/components/Background.jsx
+++ b/src/components/Background.jsx
@@ -77,20 +77,8 @@ const BackgroundContainer = styled.div`
     }
 `
 
-const Blur = styled.div`
-    background-color: ${props => props.$darkMode ? 'rgba(0, 0, 0, 0.45)' : 'rgba(255, 255, 255, 0.45)' };
-    backdrop-filter: blur(200px);
-    -webkit-backdrop-filter: blur(200px);
-    transform: translate3d(0,0,0);
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    transition: background-color 1s;
-`
-
 const Circle = styled.div`
+    filter:blur(200px);
     background-color: ${props => props.color || 'transparent'};
     height: ${props => props.height || 0};
     width: ${props => props.width || 0};
@@ -104,10 +92,9 @@ function Background() {
 
     return (
         <BackgroundContainer id='background' $darkMode={darkMode} aria-hidden={true} >
-            <Circle color={darkMode ? 'rgb(103, 8, 74)' : 'skyblue'} width={'80vw'} height={'70vw'} />
-            <Circle color={darkMode ? 'rgb(12, 52, 103)' : 'pink'} width={'50vw'} height={'50vh'} />
-            <Circle color={darkMode ? 'rgb(4, 80, 65)' : 'rgba(255, 255, 166, 0.8)'} width={'50vh'} height={'50vh'}></Circle>
-            <Blur $darkMode={darkMode}/>
+            <Circle color={darkMode ? 'rgba(103, 8, 74, 0.5)' : 'rgba(135, 206, 235, 0.5)'} width={'80vw'} height={'70vw'} />
+            <Circle color={darkMode ? 'rgba(12, 52, 103, 0.5)' : 'rgba(255, 192, 203, 0.5)'} width={'50vw'} height={'50vh'} />
+            <Circle color={darkMode ? 'rgba(4, 80, 65, 0.5)' : 'rgba(255, 255, 166, 0.5)'} width={'50vh'} height={'50vh'}></Circle>
             <BackgroundSmallDeco />
         </BackgroundContainer>
     )


### PR DESCRIPTION
어째서인지 Windows에서는 Edge에서도 Chrome에서도 backdrop-filter가 배경색은 적용되나 블러 효과가 적용되지 않았다.
그래서 backdrop-filter를 해주던 Blur 컴포넌트를 제거하고, 각 Circle에 filter 속성으로 블러효과를 주어 비슷한 효과가 나타나게 만들었다.